### PR TITLE
Send coverage to codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,5 @@ sudo: false
 cache:
   directories:
     - node_modules
+after_success:
+  - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
Add `after_success` in travis to send coverage to codecov